### PR TITLE
Improve HEC token

### DIFF
--- a/src/SplunkLogger/Configurations/HECConfiguration.cs
+++ b/src/SplunkLogger/Configurations/HECConfiguration.cs
@@ -6,6 +6,13 @@ namespace Splunk.Configurations
     /// </summary>
     public class HECConfiguration
     {
+        public enum ChannelIdOption
+        {
+            None,
+            QueryString,
+            RequestHeader
+        }
+
         /// <summary>
         /// Gets or sets the batch interval in miliseconds.
         /// </summary>
@@ -25,6 +32,16 @@ namespace Splunk.Configurations
         /// Gets or sets the splunk collector URL.
         /// </summary>
         public string SplunkCollectorUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets indication to use or not hec token autentication at query string
+        /// </summary>
+        public bool UseTokenAsQueryString { get; set; }
+
+        /// <summary>
+        /// Gets or sets indication to use or not channel identification when using raw endpoint
+        /// </summary>
+        public ChannelIdOption ChannelIdType { get; set; } = ChannelIdOption.None;
 
         /// <summary>
         /// Gets or sets the token.

--- a/src/SplunkLogger/Configurations/HECConfiguration.cs
+++ b/src/SplunkLogger/Configurations/HECConfiguration.cs
@@ -36,7 +36,7 @@ namespace Splunk.Configurations
         /// <summary>
         /// Gets or sets indication to use or not hec token autentication at query string
         /// </summary>
-        public bool UseTokenAsQueryString { get; set; }
+        public bool UseAuthTokenAsQueryString { get; set; }
 
         /// <summary>
         /// Gets or sets indication to use or not channel identification when using raw endpoint

--- a/src/SplunkLogger/LoggerFactoryExtensions.cs
+++ b/src/SplunkLogger/LoggerFactoryExtensions.cs
@@ -1,9 +1,8 @@
 ﻿using Microsoft.Extensions.Logging;
 using Splunk.Providers;
 using Splunk.Configurations;
-using Splunk;
 
-namespace Vtex
+namespace Splunk
 {
     /// <summary>
     /// This class contains ILoggerFactory extension method to simplify the process to add a Splunk logger provider.

--- a/src/SplunkLogger/Providers/SplunkHECBaseProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECBaseProvider.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Logging;
+using Splunk.Configurations;
+
+namespace Splunk.Providers
+{
+    /// <summary>
+    /// Splunk HECB ase provider.
+    /// </summary>
+    public abstract class SplunkHECBaseProvider : ILoggerProvider
+    {
+        protected HttpClient httpClient;
+
+        /// <summary>
+        /// Get a <see cref="T:Splunk.Loggers.HECJsonLogger"/> instance to the category name provided.
+        /// </summary>
+        /// <returns><see cref="T:Splunk.Loggers.HECJsonLogger"/> instance.</returns>
+        /// <param name="categoryName">Category name.</param>
+        public abstract ILogger CreateLogger(string categoryName);
+
+        /// <summary>
+        /// Releases all resource used by the <see cref="T:Splunk.Providers.SplunkHECJsonLoggerProvider"/> object.
+        /// </summary>
+        /// <remarks>Call <see cref="Dispose"/> when you are finished using the
+        /// <see cref="T:Splunk.Providers.SplunkHECJsonLoggerProvider"/>. The <see cref="Dispose"/> method leaves the
+        /// <see cref="T:Splunk.Providers.SplunkHECJsonLoggerProvider"/> in an unusable state. After calling
+        /// <see cref="Dispose"/>, you must release all references to the
+        /// <see cref="T:Splunk.Providers.SplunkHECJsonLoggerProvider"/> so the garbage collector can reclaim the memory
+        /// that the <see cref="T:Splunk.Providers.SplunkHECJsonLoggerProvider"/> was occupying.</remarks>
+        public abstract void Dispose();
+
+        /// <summary>
+        /// Create a <see cref="T:Splunk.Loggers.HECJsonLogger"/> instance to the category name provided.
+        /// </summary>
+        /// <returns>The logger instance.</returns>
+        /// <param name="categoryName">Category name.</param>
+        public abstract ILogger CreateLoggerInstance(string categoryName);
+
+        protected void SetupHttpClient(SplunkLoggerConfiguration configuration, string endPointCustomization)
+        {
+            httpClient = new HttpClient
+            {
+                BaseAddress = GetSplunkCollectorUrl(configuration, endPointCustomization),
+                Timeout = TimeSpan.FromMilliseconds(configuration.HecConfiguration.DefaultTimeoutInMiliseconds)
+            };
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Splunk", configuration.HecConfiguration.Token);
+            if (configuration.HecConfiguration.ChannelIdType == HECConfiguration.ChannelIdOption.RequestHeader)
+                httpClient.DefaultRequestHeaders.Add("x-splunk-request-channel", Guid.NewGuid().ToString());
+        }
+
+        Uri GetSplunkCollectorUrl(SplunkLoggerConfiguration configuration, string endPointCustomization)
+        {
+            var splunkCollectorUrl = configuration.HecConfiguration.SplunkCollectorUrl;
+            if (!splunkCollectorUrl.EndsWith("/", StringComparison.InvariantCulture))
+                splunkCollectorUrl = splunkCollectorUrl + "/";
+
+            if(!string.IsNullOrWhiteSpace(endPointCustomization))
+                splunkCollectorUrl = splunkCollectorUrl + endPointCustomization;
+
+            if (configuration.HecConfiguration.ChannelIdType == HECConfiguration.ChannelIdOption.QueryString)
+                splunkCollectorUrl = splunkCollectorUrl + "?channel=" + Guid.NewGuid().ToString();
+
+            return new Uri(splunkCollectorUrl);
+        }
+    }
+}

--- a/src/SplunkLogger/Providers/SplunkHECBaseProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECBaseProvider.cs
@@ -62,6 +62,12 @@ namespace Splunk.Providers
             if (configuration.HecConfiguration.ChannelIdType == HECConfiguration.ChannelIdOption.QueryString)
                 splunkCollectorUrl = splunkCollectorUrl + "?channel=" + Guid.NewGuid().ToString();
 
+            if(configuration.HecConfiguration.UseAuthTokenAsQueryString)
+            {
+                var tokenParameter = "token=" + configuration.HecConfiguration.Token;
+                splunkCollectorUrl = string.Format("{0}{1}{2}", splunkCollectorUrl, splunkCollectorUrl.Contains("?") ? "&" : "?", tokenParameter);
+            }
+
             return new Uri(splunkCollectorUrl);
         }
     }

--- a/src/SplunkLogger/Providers/SplunkHECJsonLoggerProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECJsonLoggerProvider.cs
@@ -48,7 +48,7 @@ namespace Splunk.Providers
 
             httpClient.Timeout = TimeSpan.FromMilliseconds(configuration.HecConfiguration.DefaultTimeoutInMiliseconds);
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Splunk", configuration.HecConfiguration.Token);
-
+            httpClient.DefaultRequestHeaders.Add("x-splunk-request-channel", Guid.NewGuid().ToString());
             batchController = new BatchManager(configuration.HecConfiguration.BatchSizeCount, configuration.HecConfiguration.BatchIntervalInMiliseconds, Emit);
         }
 

--- a/src/SplunkLogger/Providers/SplunkHECJsonLoggerProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECJsonLoggerProvider.cs
@@ -48,7 +48,9 @@ namespace Splunk.Providers
 
             httpClient.Timeout = TimeSpan.FromMilliseconds(configuration.HecConfiguration.DefaultTimeoutInMiliseconds);
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Splunk", configuration.HecConfiguration.Token);
-            httpClient.DefaultRequestHeaders.Add("x-splunk-request-channel", Guid.NewGuid().ToString());
+            if (configuration.HecConfiguration.ChannelIdType == HECConfiguration.ChannelIdOption.RequestHeader)
+                httpClient.DefaultRequestHeaders.Add("x-splunk-request-channel", Guid.NewGuid().ToString());
+
             batchController = new BatchManager(configuration.HecConfiguration.BatchSizeCount, configuration.HecConfiguration.BatchIntervalInMiliseconds, Emit);
         }
 

--- a/src/SplunkLogger/Providers/SplunkHECRawLoggerProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECRawLoggerProvider.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using Microsoft.Extensions.Logging;
 using Splunk.Configurations;
 using Splunk.Loggers;
@@ -14,10 +13,9 @@ namespace Splunk.Providers
     /// <summary>
     /// This class is used to provide a Splunk HEC Raw logger for each categoryName.
     /// </summary>
-    public class SplunkHECRawLoggerProvider : ILoggerProvider
+    public class SplunkHECRawLoggerProvider : SplunkHECBaseProvider, ILoggerProvider
     {
         readonly BatchManager batchManager;
-        readonly HttpClient httpClient;
         readonly LogLevel threshold;
         readonly ILoggerFormatter loggerFormatter;
         readonly ConcurrentDictionary<string, ILogger> loggers;
@@ -35,30 +33,9 @@ namespace Splunk.Providers
 
             this.loggerFormatter = loggerFormatter;
 
-            httpClient = new HttpClient();
-
-            var splunkCollectorUrl = configuration.HecConfiguration.SplunkCollectorUrl;
-            if (!splunkCollectorUrl.EndsWith("/", StringComparison.InvariantCulture))
-                splunkCollectorUrl += "/";
-            
-            if(configuration.HecConfiguration.ChannelIdType == HECConfiguration.ChannelIdOption.QueryString)
-                splunkCollectorUrl = splunkCollectorUrl + "raw?channel=" + Guid.NewGuid().ToString();
-            
-            httpClient.BaseAddress = new Uri(splunkCollectorUrl);
-
-            httpClient.Timeout = TimeSpan.FromMilliseconds(configuration.HecConfiguration.DefaultTimeoutInMiliseconds);
-
-            if(!configuration.HecConfiguration.UseTokenAsQueryString)
-                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Splunk", configuration.HecConfiguration.Token);
-            if (configuration.HecConfiguration.ChannelIdType == HECConfiguration.ChannelIdOption.RequestHeader)
-                httpClient.DefaultRequestHeaders.Add("x-splunk-request-channel", Guid.NewGuid().ToString());
+            SetupHttpClient(configuration, "raw");
 
             batchManager = new BatchManager(configuration.HecConfiguration.BatchSizeCount, configuration.HecConfiguration.BatchIntervalInMiliseconds, Emit);
-        }
-
-        ILogger CreateLoggerInstance(string categoryName)
-        {
-            return new HECRawLogger(categoryName, threshold, httpClient, batchManager, loggerFormatter);
         }
 
         /// <summary>
@@ -66,7 +43,7 @@ namespace Splunk.Providers
         /// </summary>
         /// <returns><see cref="T:Splunk.Loggers.HECRawLogger"/> instance.</returns>
         /// <param name="categoryName">Category name.</param>
-        public ILogger CreateLogger(string categoryName)
+        public override ILogger CreateLogger(string categoryName)
         {
             return loggers.GetOrAdd(categoryName, CreateLoggerInstance(categoryName));
         }
@@ -80,9 +57,19 @@ namespace Splunk.Providers
         /// <see cref="Dispose"/>, you must release all references to the
         /// <see cref="T:Splunk.Providers.SplunkHECRawLoggerProvider"/> so the garbage collector can reclaim the memory
         /// that the <see cref="T:Splunk.Providers.SplunkHECRawLoggerProvider"/> was occupying.</remarks>
-        public void Dispose()
+        public override void Dispose()
         {
             loggers.Clear();
+        }
+
+        /// <summary>
+        /// Create a <see cref="T:Splunk.Loggers.HECRawLogger"/> instance to the category name provided.
+        /// </summary>
+        /// <returns><see cref="T:Splunk.Loggers.HECRawLogger"/> instance.</returns>
+        /// <param name="categoryName">Category name.</param>
+        public override ILogger CreateLoggerInstance(string categoryName)
+        {
+            return new HECRawLogger(categoryName, threshold, httpClient, batchManager, loggerFormatter);
         }
 
         /// <summary>


### PR DESCRIPTION
**What is the purpose of this pull request?**
Add x-splunk-request-channel to request header for HEC Json logger provider.
Per the documentation this header parameter is needed.

**What issues are related to this pull request?**
- [x] close #38 Allow send HEC auth via query string
- [x] close #36 Set ChannelId for HEC optional
- [x] close #34 Support send raw channel via request header