### PR TITLE
When BatchIntervalInMiliseconds is not set Httpclient Timeout throws error

### DIFF
--- a/src/SplunkLogger/Configurations/HECConfiguration.cs
+++ b/src/SplunkLogger/Configurations/HECConfiguration.cs
@@ -14,9 +14,9 @@ namespace Splunk.Configurations
         }
 
         /// <summary>
-        /// Gets or sets the batch interval in miliseconds.
+        /// Gets or sets the batch interval in miliseconds (default 1000).
         /// </summary>
-        public uint BatchIntervalInMiliseconds { get; set; }
+        public uint BatchIntervalInMiliseconds { get; set; } = 1000;
 
         /// <summary>
         /// Gets or sets the batch size count.

--- a/src/SplunkLogger/Configurations/HECConfiguration.cs
+++ b/src/SplunkLogger/Configurations/HECConfiguration.cs
@@ -14,9 +14,9 @@ namespace Splunk.Configurations
         }
 
         /// <summary>
-        /// Gets or sets the batch interval in miliseconds (default 1000).
+        /// Gets or sets the batch interval in miliseconds.
         /// </summary>
-        public uint BatchIntervalInMiliseconds { get; set; } = 1000;
+        public uint BatchIntervalInMilliseconds { get; set; }
 
         /// <summary>
         /// Gets or sets the batch size count.

--- a/src/SplunkLogger/Providers/SplunkHECBaseProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECBaseProvider.cs
@@ -42,9 +42,12 @@ namespace Splunk.Providers
         {
             httpClient = new HttpClient
             {
-                BaseAddress = GetSplunkCollectorUrl(configuration, endPointCustomization),
-                Timeout = TimeSpan.FromMilliseconds(configuration.HecConfiguration.DefaultTimeoutInMiliseconds)
+                BaseAddress = GetSplunkCollectorUrl(configuration, endPointCustomization)
             };
+
+            if (configuration.HecConfiguration.DefaultTimeoutInMiliseconds > 0)
+                httpClient.Timeout = TimeSpan.FromMilliseconds(configuration.HecConfiguration.DefaultTimeoutInMiliseconds);
+
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Splunk", configuration.HecConfiguration.Token);
             if (configuration.HecConfiguration.ChannelIdType == HECConfiguration.ChannelIdOption.RequestHeader)
                 httpClient.DefaultRequestHeaders.Add("x-splunk-request-channel", Guid.NewGuid().ToString());

--- a/src/SplunkLogger/Providers/SplunkHECJsonLoggerProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECJsonLoggerProvider.cs
@@ -38,7 +38,7 @@ namespace Splunk.Providers
 
             SetupHttpClient(configuration, "event");
 
-            batchController = new BatchManager(configuration.HecConfiguration.BatchSizeCount, configuration.HecConfiguration.BatchIntervalInMiliseconds, Emit);
+            batchController = new BatchManager(configuration.HecConfiguration.BatchSizeCount, configuration.HecConfiguration.BatchIntervalInMilliseconds, Emit);
         }
 
         /// <summary>
@@ -87,7 +87,41 @@ namespace Splunk.Providers
             httpClient.PostAsync(string.Empty, stringContent)
                       .ContinueWith(task => {
                           if (task.IsCompletedSuccessfully)
-                              Debug.WriteLine("Splunk HEC RAW Status: Sucess");
+                              switch (task.Result.StatusCode)
+                              {
+                                  case System.Net.HttpStatusCode.OK:
+                                      Debug.WriteLine("Splunk HEC JSON Status: Request completed successfully.");
+                                      break;
+                                  case System.Net.HttpStatusCode.Created:
+                                      Debug.WriteLine("Splunk HEC JSON Status: Create request completed successfully.");
+                                      break;
+                                  case System.Net.HttpStatusCode.BadRequest:
+                                      Debug.WriteLine("Splunk HEC JSON Status: Request error. See response body for details.");
+                                      break;
+                                  case System.Net.HttpStatusCode.Unauthorized:
+                                      Debug.WriteLine("Splunk HEC JSON Status: Authentication failure, invalid access credentials.");
+                                      break;
+                                  case System.Net.HttpStatusCode.PaymentRequired:
+                                      Debug.WriteLine("Splunk HEC JSON Status: In-use Splunk Enterprise license disables this feature.");
+                                      break;
+                                  case System.Net.HttpStatusCode.Forbidden:
+                                      Debug.WriteLine("Splunk HEC JSON Status: Insufficient permission.");
+                                      break;
+                                  case System.Net.HttpStatusCode.NotFound:
+                                      Debug.WriteLine("Splunk HEC JSON Status: Requested endpoint does not exist.");
+                                      break;
+                                  case System.Net.HttpStatusCode.Conflict:
+                                      Debug.WriteLine("Splunk HEC JSON Status: Invalid operation for this endpoint. See response body for details.");
+                                      break;
+                                  case System.Net.HttpStatusCode.InternalServerError:
+                                      Debug.WriteLine("Splunk HEC JSON Status: Unspecified internal server error. See response body for details.");
+                                      break;
+                                  case System.Net.HttpStatusCode.ServiceUnavailable:
+                                      Debug.WriteLine("Splunk HEC JSON Status: Feature is disabled in configuration file.");
+                                      break;
+                                  default:
+                                      break;
+                              }
                           else if (task.IsCanceled)
                               Debug.WriteLine("Splunk HEC RAW Status: Canceled");
                           else

--- a/src/SplunkLogger/Providers/SplunkHECRawLoggerProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECRawLoggerProvider.cs
@@ -35,7 +35,7 @@ namespace Splunk.Providers
 
             SetupHttpClient(configuration, "raw");
 
-            batchManager = new BatchManager(configuration.HecConfiguration.BatchSizeCount, configuration.HecConfiguration.BatchIntervalInMiliseconds, Emit);
+            batchManager = new BatchManager(configuration.HecConfiguration.BatchSizeCount, configuration.HecConfiguration.BatchIntervalInMilliseconds, Emit);
         }
 
         /// <summary>
@@ -83,7 +83,41 @@ namespace Splunk.Providers
             httpClient.PostAsync(string.Empty, stringContent)
                       .ContinueWith(task => {
                           if (task.IsCompletedSuccessfully)
-                              Debug.WriteLine("Splunk HEC RAW Status: Sucess");
+                              switch (task.Result.StatusCode)
+                              {
+                                  case System.Net.HttpStatusCode.OK:
+                                      Debug.WriteLine("Splunk HEC RAW Status: Request completed successfully.");
+                                      break;
+                                  case System.Net.HttpStatusCode.Created:
+                                      Debug.WriteLine("Splunk HEC RAW Status: Create request completed successfully.");
+                                      break;
+                                  case System.Net.HttpStatusCode.BadRequest:
+                                      Debug.WriteLine("Splunk HEC RAW Status: Request error. See response body for details.");
+                                      break;
+                                  case System.Net.HttpStatusCode.Unauthorized:
+                                      Debug.WriteLine("Splunk HEC RAW Status: Authentication failure, invalid access credentials.");
+                                      break;
+                                  case System.Net.HttpStatusCode.PaymentRequired:
+                                      Debug.WriteLine("Splunk HEC RAW Status: In-use Splunk Enterprise license disables this feature.");
+                                      break;
+                                  case System.Net.HttpStatusCode.Forbidden:
+                                      Debug.WriteLine("Splunk HEC RAW Status: Insufficient permission.");
+                                      break;
+                                  case System.Net.HttpStatusCode.NotFound:
+                                      Debug.WriteLine("Splunk HEC RAW Status: Requested endpoint does not exist.");
+                                      break;
+                                  case System.Net.HttpStatusCode.Conflict:
+                                      Debug.WriteLine("Splunk HEC RAW Status: Invalid operation for this endpoint. See response body for details.");
+                                      break;
+                                  case System.Net.HttpStatusCode.InternalServerError:
+                                      Debug.WriteLine("Splunk HEC RAW Status: Unspecified internal server error. See response body for details.");
+                                      break;
+                                  case System.Net.HttpStatusCode.ServiceUnavailable:
+                                      Debug.WriteLine("Splunk HEC RAW Status: Feature is disabled in configuration file.");
+                                      break;
+                                  default:
+                                      break;
+                              }
                           else if (task.IsCanceled)
                               Debug.WriteLine("Splunk HEC RAW Status: Canceled");
                           else


### PR DESCRIPTION
**What is the purpose of this pull request?**
Avoid set invalid timeout for httpClient and improved debug from splunk response

**What issues are related to this pull request?**
- [x] close #44 Use HttpStatusCode to decode response from Splunk
- [x] close #42 When BatchIntervalInMiliseconds is not set Httpclient Timeout throws error