### PR TITLE
Add option to pass a HttpMessageHandler to the HttpClient

### DIFF
--- a/src/SplunkLogger/LoggerFactoryExtensions.cs
+++ b/src/SplunkLogger/LoggerFactoryExtensions.cs
@@ -2,6 +2,7 @@
 using Splunk.Providers;
 using Splunk.Configurations;
 using System.Collections.Generic;
+using System.Net.Http;
 
 namespace Splunk
 {
@@ -18,11 +19,12 @@ namespace Splunk
         /// <param name="loggerFactory">Logger factory.</param>
         /// <param name="configuration">Configuration.</param>
         /// <param name="formatter">Custom text formatter.</param>
-        public static ILoggerFactory AddHECRawSplunkLogger(this ILoggerFactory loggerFactory, SplunkLoggerConfiguration configuration, ILoggerFormatter formatter = null)
+        /// <param name="httpMessageHandler">The HTTP handler stack to use for sending requests.</param>
+        public static ILoggerFactory AddHECRawSplunkLogger(this ILoggerFactory loggerFactory, SplunkLoggerConfiguration configuration, ILoggerFormatter formatter = null, HttpMessageHandler httpMessageHandler = null)
         {
             if (formatter == null)
                 formatter = DefaultLoggerFormatter;
-            loggerFactory.AddProvider(new SplunkHECRawLoggerProvider(configuration, formatter));
+            loggerFactory.AddProvider(new SplunkHECRawLoggerProvider(configuration, formatter, httpMessageHandler));
             return loggerFactory;
         }
 
@@ -32,11 +34,12 @@ namespace Splunk
         /// <param name="loggerFactory">Logger factory.</param>
         /// <param name="configuration">Configuration.</param>
         /// <param name="formatter">Custom text formatter.</param>
-        public static ILoggerFactory AddHECJsonSplunkLogger(this ILoggerFactory loggerFactory, SplunkLoggerConfiguration configuration, ILoggerFormatter formatter = null)
+        /// <param name="httpMessageHandler">The HTTP handler stack to use for sending requests.</param>
+        public static ILoggerFactory AddHECJsonSplunkLogger(this ILoggerFactory loggerFactory, SplunkLoggerConfiguration configuration, ILoggerFormatter formatter = null, HttpMessageHandler httpMessageHandler = null)
         {
             if (formatter == null)
                 formatter = DefaultLoggerFormatter;
-            loggerFactory.AddProvider(new SplunkHECJsonLoggerProvider(configuration, formatter));
+            loggerFactory.AddProvider(new SplunkHECJsonLoggerProvider(configuration, formatter, httpMessageHandler));
             return loggerFactory;
         }
 

--- a/src/SplunkLogger/Providers/SplunkHECBaseProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECBaseProvider.cs
@@ -18,9 +18,9 @@ namespace Splunk.Providers
         protected ILogger loggerInstance;
         protected HttpClient httpClient;
 
-        public SplunkHECBaseProvider(SplunkLoggerConfiguration configuration, string endPointCustomization)
+        public SplunkHECBaseProvider(SplunkLoggerConfiguration configuration, string endPointCustomization, HttpMessageHandler httpMessageHandler = null)
         {
-            SetupHttpClient(configuration, endPointCustomization);
+            SetupHttpClient(configuration, endPointCustomization, httpMessageHandler);
         }
 
         /// <summary>
@@ -41,9 +41,9 @@ namespace Splunk.Providers
         /// that the <see cref="T:Splunk.Providers.SplunkHECJsonLoggerProvider"/> was occupying.</remarks>
         public abstract void Dispose();
 
-        void SetupHttpClient(SplunkLoggerConfiguration configuration, string endPointCustomization)
+        void SetupHttpClient(SplunkLoggerConfiguration configuration, string endPointCustomization, HttpMessageHandler httpMessageHandler)
         {
-            httpClient = new HttpClient
+            httpClient = new HttpClient(httpMessageHandler ?? new HttpClientHandler())
             {
                 BaseAddress = GetSplunkCollectorUrl(configuration, endPointCustomization)
             };

--- a/src/SplunkLogger/Providers/SplunkHECJsonLoggerProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECJsonLoggerProvider.cs
@@ -24,8 +24,9 @@ namespace Splunk.Providers
         /// </summary>
         /// <param name="configuration">Splunk configuration instance for HEC.</param>
         /// <param name="loggerFormatter">Formatter instance.</param>
-        public SplunkHECJsonLoggerProvider(SplunkLoggerConfiguration configuration, ILoggerFormatter loggerFormatter = null)
-            : base(configuration, "event")
+        /// <param name="httpMessageHandler">The HTTP handler stack to use for sending requests.</param>
+        public SplunkHECJsonLoggerProvider(SplunkLoggerConfiguration configuration, ILoggerFormatter loggerFormatter = null, HttpMessageHandler httpMessageHandler = null)
+            : base(configuration, "event", httpMessageHandler)
         {
             this.loggerFormatter = loggerFormatter;
             loggers = new ConcurrentDictionary<string, ILogger>();

--- a/src/SplunkLogger/Providers/SplunkHECJsonLoggerProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECJsonLoggerProvider.cs
@@ -13,6 +13,7 @@ namespace Splunk.Providers
     /// <summary>
     /// This class is used to provide a Splunk HEC Json logger for each categoryName.
     /// </summary>
+    [ProviderAlias("Splunk")]
     public class SplunkHECJsonLoggerProvider : SplunkHECBaseProvider, ILoggerProvider
     {
         readonly BatchManager batchManager;

--- a/src/SplunkLogger/Providers/SplunkHECRawLoggerProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECRawLoggerProvider.cs
@@ -12,6 +12,7 @@ namespace Splunk.Providers
     /// <summary>
     /// This class is used to provide a Splunk HEC Raw logger for each categoryName.
     /// </summary>
+    [ProviderAlias("Splunk")]
     public class SplunkHECRawLoggerProvider : SplunkHECBaseProvider, ILoggerProvider
     {
         readonly BatchManager batchManager;

--- a/src/SplunkLogger/Providers/SplunkHECRawLoggerProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkHECRawLoggerProvider.cs
@@ -23,8 +23,9 @@ namespace Splunk.Providers
         /// </summary>
         /// <param name="configuration">Splunk configuration instance for HEC.</param>
         /// <param name="loggerFormatter">Formatter instance.</param>
-        public SplunkHECRawLoggerProvider(SplunkLoggerConfiguration configuration, ILoggerFormatter loggerFormatter = null)
-            :base(configuration, "raw")
+        /// <param name="httpMessageHandler">The HTTP handler stack to use for sending requests.</param>
+        public SplunkHECRawLoggerProvider(SplunkLoggerConfiguration configuration, ILoggerFormatter loggerFormatter = null, HttpMessageHandler httpMessageHandler = null)
+            :base(configuration, "raw", httpMessageHandler)
         {
             this.loggerFormatter = loggerFormatter;
             loggers = new ConcurrentDictionary<string, ILogger>();

--- a/src/SplunkLogger/Providers/SplunkTcpLoggerProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkTcpLoggerProvider.cs
@@ -9,6 +9,7 @@ namespace Splunk.Providers
     /// <summary>
     /// This class is used to provide a Splunk Socket Tcp logger for each categoryName.
     /// </summary>
+    [ProviderAlias("Splunk")]
     public class SplunkTcpLoggerProvider : ILoggerProvider
     {
         readonly ILoggerFormatter loggerFormatter;

--- a/src/SplunkLogger/Providers/SplunkUdpLoggerProvider.cs
+++ b/src/SplunkLogger/Providers/SplunkUdpLoggerProvider.cs
@@ -9,6 +9,7 @@ namespace Splunk.Providers
     /// <summary>
     /// This class is used to provide a Splunk Socket Udp logger for each categoryName.
     /// </summary>
+    [ProviderAlias("Splunk")]
     public class SplunkUdpLoggerProvider : ILoggerProvider
     {
         readonly ILoggerFormatter loggerFormatter;


### PR DESCRIPTION
This change allow to optionally pass a HttpMessageHandler to the used HttpClient inside the logger.
Example:
```
var config = builder.Configuration.GetSection("Splunk").Get<SplunkLoggerConfiguration>();
var handler = new HttpClientHandler
{
     Proxy = new WebProxy("http://localhost:8080")
};
builder.Logging.AddProvider(new SplunkHECJsonLoggerProvider(config, null, handler));
```
To control, how the http client behaves and allows different use cases like adding a proxy, config ssl validation, ....